### PR TITLE
Add PixiJS particle overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A faithful browser-based recreation of the classic 1991 MS-DOS turn-based artill
 - **Shop System**: Buy weapons and utilities between rounds
 - **Sound Effects**: Procedurally generated retro sounds with volume control
 - **Responsive Controls**: Keyboard and mouse support
+- **WebGL Particle Effects**: Powered by PixiJS for enhanced explosions
 
 ## Quick Start
 
@@ -64,6 +65,7 @@ Simply open `index.html` in a modern web browser
 - Web Audio API for sound generation
 - CSS3 with custom animations
 - Motion One for UI transitions
+- PixiJS for WebGL particle effects
 - Puppeteer for visual testing
 
 ## Project Structure

--- a/index.html
+++ b/index.html
@@ -87,6 +87,8 @@
 
             <!-- Game Canvas -->
             <canvas id="game-canvas"></canvas>
+            <!-- Effects Canvas for PixiJS overlay -->
+            <canvas id="fx-canvas"></canvas>
 
             <!-- Fire Button -->
             <button id="fire-btn" class="fire-button">FIRE!</button>
@@ -118,6 +120,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.4/howler.min.js"></script>
     <!-- Motion One for UI animations -->
     <script src="https://cdn.jsdelivr.net/npm/@motionone/dom/dist/motion.min.js"></script>
+    <!-- PixiJS for enhanced particle effects -->
+    <script src="https://cdn.jsdelivr.net/npm/pixi.js@7/dist/browser/pixi.min.js"></script>
     
     <script src="js/menu-background.js"></script>
     <script src="js/spatial-grid.js"></script>
@@ -131,6 +135,7 @@
     <script src="js/weapons.js"></script>
     <script src="js/projectile.js"></script>
     <script src="js/effects.js"></script>
+    <script src="js/pixi-effects.js"></script>
     <script src="js/ai.js"></script>
     <script src="js/shop.js"></script>
     <script src="js/sound.js"></script>

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,6 @@
 // Main Game Class
 class Game {
-    constructor(canvas, ui) {
+    constructor(canvas, ui, fxCanvas = null) {
         this.canvas = canvas;
         this.ctx = canvas.getContext('2d');
         this.ui = ui;
@@ -23,7 +23,11 @@ class Game {
         this.terrain = null;
         this.physics = new Physics();
         this.projectileManager = new ProjectileManager();
-        this.effectsSystem = new EffectsSystem();
+        if (fxCanvas && window.PIXI) {
+            this.effectsSystem = new PixiEffectsSystem(fxCanvas);
+        } else {
+            this.effectsSystem = new EffectsSystem();
+        }
         this.shop = new Shop();
         this.soundSystem = new SoundSystem();
         

--- a/js/main.js
+++ b/js/main.js
@@ -2,12 +2,13 @@
 document.addEventListener('DOMContentLoaded', () => {
     // Get canvas
     const canvas = document.getElementById('game-canvas');
+    const fxCanvas = document.getElementById('fx-canvas');
     
     // Create UI manager
     const ui = new UIManager();
     
     // Create game instance
-    const game = new Game(canvas, ui);
+    const game = new Game(canvas, ui, fxCanvas);
     
     // Make game accessible globally for UI
     window.game = game;

--- a/js/pixi-effects.js
+++ b/js/pixi-effects.js
@@ -1,0 +1,42 @@
+// PixiJS-powered particle effects system
+class PixiEffectsSystem extends EffectsSystem {
+    constructor(canvas) {
+        super();
+        this.app = new PIXI.Application({
+            view: canvas,
+            width: canvas.width,
+            height: canvas.height,
+            transparent: true,
+            autoStart: false,
+            antialias: true
+        });
+        this.graphics = new PIXI.Graphics();
+        this.app.stage.addChild(this.graphics);
+        if (PIXI.filters && PIXI.filters.AdvancedBloomFilter) {
+            this.app.stage.filters = [new PIXI.filters.AdvancedBloomFilter({
+                threshold: 0.5,
+                bloomScale: 1.2,
+                brightness: 1.1
+            })];
+        }
+    }
+
+    draw() {
+        this.graphics.clear();
+        for (const p of this.particles) {
+            const alpha = p.fade ? (p.lifetime / p.maxLifetime) : 1;
+            const color = PIXI.utils.string2hex(p.color);
+            this.graphics.beginFill(color, alpha);
+            if (p.isSolid) {
+                this.graphics.drawRect(p.x - p.size / 2, p.y - p.size / 2, p.size, p.size);
+            } else {
+                this.graphics.drawCircle(p.x, p.y, p.size / 2);
+            }
+            this.graphics.endFill();
+        }
+        this.app.renderer.render(this.app.stage);
+    }
+}
+
+// Export globally
+window.PixiEffectsSystem = PixiEffectsSystem;

--- a/style.css
+++ b/style.css
@@ -257,6 +257,17 @@ body {
     touch-action: none; /* Prevent default touch behaviors */
 }
 
+/* Overlay canvas for PixiJS effects */
+#fx-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 2;
+}
+
 /* Fire Button Positioning */
 #fire-btn {
     position: absolute;


### PR DESCRIPTION
## Summary
- overlay a new `fx-canvas` for visual effects
- include PixiJS and implement `PixiEffectsSystem`
- use the Pixi system when available in `Game`
- pass the new canvas from `main.js`
- document PixiJS usage and new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68421086ab148331aa5f9f8ab6b12df1